### PR TITLE
OZ-445: Modified PropertySource annotation in `OdooOpenmrsConfig`.

### DIFF
--- a/src/main/java/com/ozonehis/eip/odooopenmrs/config/OdooOpenmrsConfig.java
+++ b/src/main/java/com/ozonehis/eip/odooopenmrs/config/OdooOpenmrsConfig.java
@@ -4,5 +4,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
-@PropertySource("eip-odoo-openmrs.properties")
+@PropertySource(
+        value = {"eip-odoo-openmrs.properties", "classpath:eip-odoo-openmrs.properties"},
+        ignoreResourceNotFound = true)
 public class OdooOpenmrsConfig {}


### PR DESCRIPTION
The annotation is configured to load properties from the `eip-odoo-openmrs.properties` file located at the **root** and **classpath**. If the properties file is not found, the application will not throw an error due to the 'ignoreResourceNotFound' attribute set to true. This change allows the application to be more flexible in terms of configuration management.