### PR TITLE
fix: null-safe PartnerMapper for missing FHIR birthDate + empty given names

### DIFF
--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/mapper/odoo/PartnerMapper.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/mapper/odoo/PartnerMapper.java
@@ -52,8 +52,10 @@ public class PartnerMapper implements ToOdooMapping<Patient, Partner> {
         partner.setPartnerComment(patientIdentifier);
         partner.setPartnerExternalId(patientIdentifier);
         partner.setPartnerName(patientName);
-        partner.setPartnerBirthDate(
-                OdooUtils.convertEEEMMMddDateToOdooFormat(patient.getBirthDate().toString()));
+        if (patient.getBirthDate() != null) {
+            partner.setPartnerBirthDate(OdooUtils.convertEEEMMMddDateToOdooFormat(
+                    patient.getBirthDate().toString()));
+        }
 
         addAddress(patient, partner);
         return partner;
@@ -67,9 +69,13 @@ public class PartnerMapper implements ToOdooMapping<Patient, Partner> {
     }
 
     protected Optional<String> getPatientName(Patient patient) {
-        return patient.getName().stream()
-                .findFirst()
-                .map(name -> name.getGiven().get(0) + " " + name.getFamily());
+        return patient.getName().stream().findFirst().map(name -> {
+            String given = (name.getGiven() != null && !name.getGiven().isEmpty())
+                    ? name.getGiven().get(0).getValueAsString()
+                    : "";
+            String family = name.getFamily() != null ? name.getFamily() : "";
+            return (given + " " + family).trim();
+        });
     }
 
     protected void addAddress(Patient patient, Partner partner) {

--- a/odoo-openmrs/src/test/java/com/ozonehis/eip/odoo/openmrs/mapper/odoo/PartnerMapperTest.java
+++ b/odoo-openmrs/src/test/java/com/ozonehis/eip/odoo/openmrs/mapper/odoo/PartnerMapperTest.java
@@ -125,6 +125,43 @@ class PartnerMapperTest {
         assertEquals("Test Address Line 1", partner.getPartnerStreet());
     }
 
+    @Test
+    public void whenBirthDateIsNullThenShouldMapWithoutNpe() {
+        // Setup — Patient with NO birthDate (FHIR resource permits this)
+        Patient patient = new Patient();
+        patient.setId("123");
+        patient.setActive(true);
+        patient.setName(
+                Collections.singletonList(new HumanName().setFamily("Doe").addGiven("John")));
+        patient.setIdentifier(Collections.singletonList(
+                new Identifier().setUse(Identifier.IdentifierUse.OFFICIAL).setValue("10IDH12H")));
+
+        // Act — must NOT throw NullPointerException
+        Partner partner = partnerMapper.toOdoo(patient);
+
+        // Assert — partner created, birthDate left unset (null), other fields populated
+        assertEquals("123", partner.getPartnerRef());
+        assertEquals("John Doe", partner.getPartnerName());
+        assertEquals("10IDH12H", partner.getPartnerComment());
+        assertNull(partner.getPartnerBirthDate());
+    }
+
+    @Test
+    public void whenGivenNameIsEmptyThenShouldMapWithFamilyOnly() {
+        // Setup — HumanName with family but NO given names (e.g. mononyms)
+        Patient patient = new Patient();
+        patient.setId("123");
+        patient.setActive(true);
+        patient.setName(Collections.singletonList(new HumanName().setFamily("Doe")));
+
+        // Act — must NOT throw IndexOutOfBoundsException on getGiven().get(0)
+        Partner partner = partnerMapper.toOdoo(patient);
+
+        // Assert — partner created with family name only
+        assertEquals("123", partner.getPartnerRef());
+        assertEquals("Doe", partner.getPartnerName());
+    }
+
     private static Patient getPatient() {
         Patient patient = new Patient();
         patient.setId("123");


### PR DESCRIPTION
## Problem

`PartnerMapper.toOdoo` aborts FHIR Patient → Odoo res.partner sync with two NullPointer-class exceptions when the FHIR Patient resource lacks optional fields:

1. **`PartnerMapper.java:56`** — `partner.setPartnerBirthDate(OdooUtils.convertEEEMMMddDateToOdooFormat(patient.getBirthDate().toString()));`
   FHIR R4 declares `Patient.birthDate` as cardinality `0..1`. When absent, `getBirthDate()` returns `null`, and `null.toString()` throws `NullPointerException` ("Cannot invoke java.util.Date.toString() because the return value of org.hl7.fhir.r4.model.Patient.getBirthDate() is null").

2. **`PartnerMapper.getPatientName:72`** — `name -> name.getGiven().get(0) + " " + name.getFamily()`
   FHIR R4 declares `HumanName.given` as cardinality `0..*`. Mononym patients (single-name cultures) and minimum-data records have an empty list, so `getGiven().get(0)` throws `IndexOutOfBoundsException`.

These bugs surfaced in production while integrating EIP into a Cameroon hospital deployment with a synthetic patient corpus. Real hospital data has the same shape: many minimum-data registrations lack birthDate.

## Fix

- Wrap `setPartnerBirthDate` in a null check so the field stays unset on the Odoo `res.partner` instead of aborting the whole exchange.
- In `getPatientName`, guard `getGiven()` for null and empty list, and `getFamily()` for null. Use `.getValueAsString()` on the `StringType` for explicit unwrapping.

Pure null-safety. No behavioral change for happy-path Patients (existing test `shouldMapFhirPatientToOdooPartner` still passes unchanged).

## Tests

Two new unit tests in `PartnerMapperTest`:
- `whenBirthDateIsNullThenShouldMapWithoutNpe` — Patient without birthDate maps to a Partner with `partnerBirthDate == null` and no exception.
- `whenGivenNameIsEmptyThenShouldMapWithFamilyOnly` — Patient with family name only maps to `partnerName == "Doe"`.

\`\`\`
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
\`\`\`

## Provenance

Bug discovered + fix verified end-to-end at SHG hospital deployment (100/100 synthetic patients propagated through Debezium → fhir-router → patient-to-partner-router → odoo-create-partner-route → res.partner). Full incident write-up in our internal Story 1.6k.

A second PR will follow with the create-vs-update fix in `PatientProcessor` (separate concern; small).