### PR TITLE
fix: force event type to 'c' in PatientProcessor when partner missing in Odoo

### DIFF
--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/PatientProcessor.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/PatientProcessor.java
@@ -50,18 +50,30 @@ public class PatientProcessor implements Processor {
 
             String eventType = message.getHeader(HEADER_FHIR_EVENT_TYPE, String.class);
             Partner fetchedPartner = partnerHandler.getPartnerByID(partner.getPartnerRef());
+            Map<String, Object> headers = new HashMap<>();
             if (fetchedPartner != null) {
                 partner.setPartnerId(fetchedPartner.getPartnerId());
-                Map<String, Object> headers = new HashMap<>();
                 headers.put(Constants.HEADER_ODOO_ID_ATTRIBUTE_VALUE, List.of(partner.getPartnerId()));
 
-                if (eventType.equals("c") || eventType.equals("u")) {
+                if ("c".equals(eventType) || "u".equals(eventType)) {
                     headers.put(HEADER_FHIR_EVENT_TYPE, "u");
                 } else {
                     headers.put(HEADER_FHIR_EVENT_TYPE, "d");
                 }
-                exchange.getMessage().setHeaders(headers);
+            } else {
+                // Partner does not yet exist in Odoo. The inbound event type may be "u"
+                // (e.g. Debezium captured an OpenMRS patient.date_changed UPDATE that is
+                // the patient's first sync to Odoo). Forcing "c" here so the route
+                // dispatches to odoo-create-partner-route; otherwise the message is
+                // silently no-op'd by odoo-update-partner-route on a non-existent
+                // partner, and the new patient never reaches Odoo.
+                if ("d".equals(eventType)) {
+                    headers.put(HEADER_FHIR_EVENT_TYPE, "d");
+                } else {
+                    headers.put(HEADER_FHIR_EVENT_TYPE, "c");
+                }
             }
+            exchange.getMessage().setHeaders(headers);
             exchange.getMessage().setBody(partner);
         } catch (Exception e) {
             throw new CamelExecutionException("Error processing Patient", exchange, e);

--- a/odoo-openmrs/src/test/java/com/ozonehis/eip/odoo/openmrs/processors/PatientProcessorTest.java
+++ b/odoo-openmrs/src/test/java/com/ozonehis/eip/odoo/openmrs/processors/PatientProcessorTest.java
@@ -112,6 +112,53 @@ class PatientProcessorTest extends BaseProcessorTest {
     }
 
     @Test
+    void shouldForceCreateEventTypeWhenPartnerMissingAndInboundIsUpdate() {
+        // Arrange — Debezium captures patient.date_changed (operation=u) but the
+        // partner has not been synced to Odoo yet (fetchedPartner = null). Without
+        // the forcing logic the inbound "u" leaks through and the route dispatches
+        // to odoo-update-partner-route, silently no-op'ing on a non-existent partner.
+        Patient patient = new Patient();
+        patient.setId(PATIENT_ID);
+        Partner partner = new Partner();
+        partner.setPartnerRef(PATIENT_ID);
+
+        Exchange exchange = createExchange(patient, "u");
+
+        // Mock behavior — fetchedPartner is null (new patient)
+        when(partnerMapper.toOdoo(patient)).thenReturn(partner);
+        when(partnerHandler.getPartnerByID(partner.getPartnerRef())).thenReturn(null);
+
+        // Act
+        patientProcessor.process(exchange);
+
+        // Assert — header forced to "c" so the route creates the partner
+        assertEquals("c", exchange.getMessage().getHeader(HEADER_FHIR_EVENT_TYPE));
+        verify(partnerMapper, times(1)).toOdoo(patient);
+    }
+
+    @Test
+    void shouldPreserveDeleteEventTypeWhenPartnerMissing() {
+        // Arrange — delete of a partner that was never synced. Should remain "d"
+        // (the route discards or no-op's safely).
+        Patient patient = new Patient();
+        patient.setId(PATIENT_ID);
+        Partner partner = new Partner();
+        partner.setPartnerRef(PATIENT_ID);
+
+        Exchange exchange = createExchange(patient, "d");
+
+        // Mock behavior — fetchedPartner is null
+        when(partnerMapper.toOdoo(patient)).thenReturn(partner);
+        when(partnerHandler.getPartnerByID(partner.getPartnerRef())).thenReturn(null);
+
+        // Act
+        patientProcessor.process(exchange);
+
+        // Assert — "d" preserved, NOT forced to "c"
+        assertEquals("d", exchange.getMessage().getHeader(HEADER_FHIR_EVENT_TYPE));
+    }
+
+    @Test
     void shouldProcessPatientWithDeleteEventType() {
         // Arrange
         Patient patient = new Patient();


### PR DESCRIPTION
## Problem

`PatientProcessor.process` silently drops messages for new patients on the FHIR Patient → Odoo res.partner sync path. The bug is in the create-vs-update event-type decision:

\`\`\`java
String eventType = message.getHeader(HEADER_FHIR_EVENT_TYPE, String.class);
Partner fetchedPartner = partnerHandler.getPartnerByID(partner.getPartnerRef());
if (fetchedPartner != null) {
    // ... headers.put(HEADER_FHIR_EVENT_TYPE, "u" or "d") ...
}
// else branch: headers map is NEVER populated, inbound header flows through
\`\`\`

When `fetchedPartner == null` (the partner has not yet been synced to Odoo), the headers map is never populated. The inbound `HEADER_FHIR_EVENT_TYPE` flows through unchanged. In production this header is **typically `"u"`**, because the Debezium watcher fires on `patient.date_changed` UPDATE events — even for a patient's very first sync (any `INSERT` into `patient_identifier`, `person_name`, `person_address`, etc. propagates a UPDATE on `patient.date_changed`).

The downstream `PatientRouting` `choice()` then dispatches the message to `odoo-update-partner-route`, which silently no-ops on a non-existent partner. The new patient never reaches Odoo, and **no error is logged** — the message simply disappears.

This is the more impactful of the two bugs we hit. The route looks healthy from `/actuator` (Camel routes loaded, exchanges processed), but no partners are ever created.

## Fix

- Always populate the headers map (instead of only when `fetchedPartner != null`).
- When `fetchedPartner == null` and the inbound event is not `"d"`, force `HEADER_FHIR_EVENT_TYPE = "c"` so the route dispatches to `odoo-create-partner-route`.
- Preserve `"d"` when present (deletion of a never-synced partner is a no-op; no need to flip it to "c").

The existing happy-path tests (`shouldProcessPatientWithCreateEventType`, `shouldProcessPatientWithUpdateEventType`, `shouldProcessPatientWithDeleteEventType`) all pass unchanged.

## Tests

Two new unit tests in `PatientProcessorTest`:
- `shouldForceCreateEventTypeWhenPartnerMissingAndInboundIsUpdate` — inbound `"u"`, fetchedPartner `null` → header forced to `"c"`. **Fails on upstream main, passes on this PR.**
- `shouldPreserveDeleteEventTypeWhenPartnerMissing` — inbound `"d"`, fetchedPartner `null` → header preserved as `"d"`.

\`\`\`
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
\`\`\`

## Provenance

Discovered while integrating EIP into a Cameroon hospital deployment. After applying both this fix and the null-safe `PartnerMapper` fix (#61), 100/100 synthetic patients propagated end-to-end through Debezium → fhir-router → patient-to-partner-router → odoo-create-partner-route → res.partner. Before the fix, zero partners were created despite all routes loading and FHIR fetches returning HTTP 200.

Companion PR: #61 (null-safe PartnerMapper).