### PR TITLE
C2C-461: Add functionality to sync orders in Odoo as per Encounter location

### DIFF
--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/Constants.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/Constants.java
@@ -23,6 +23,8 @@ public class Constants {
 
     public static final String PRODUCT_MODEL = "product.product";
 
+    public static final String COMPANY_MODEL = "res.company";
+
     public static final String IR_MODEL = "ir.model.data";
 
     public static final String CREATE_METHOD = "create";

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/client/OdooUtils.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/client/OdooUtils.java
@@ -64,10 +64,6 @@ public class OdooUtils {
                 String propertyValue = environment.getProperty(jsonProperty.value());
                 String key = propertyValue == null ? jsonProperty.value() : propertyValue;
                 Object value = field.get(object);
-                // Skip null values so we don't override Odoo defaults (e.g. company_id NOT NULL on sale.order).
-                if (value == null) {
-                    continue;
-                }
                 map.put(key, value);
             }
         }

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/client/OdooUtils.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/client/OdooUtils.java
@@ -64,6 +64,10 @@ public class OdooUtils {
                 String propertyValue = environment.getProperty(jsonProperty.value());
                 String key = propertyValue == null ? jsonProperty.value() : propertyValue;
                 Object value = field.get(object);
+                // Skip null values so we don't override Odoo defaults (e.g. company_id NOT NULL on sale.order).
+                if (value == null) {
+                    continue;
+                }
                 map.put(key, value);
             }
         }

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/client/OdooUtils.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/client/OdooUtils.java
@@ -64,7 +64,9 @@ public class OdooUtils {
                 String propertyValue = environment.getProperty(jsonProperty.value());
                 String key = propertyValue == null ? jsonProperty.value() : propertyValue;
                 Object value = field.get(object);
-                map.put(key, value);
+                if (value != null) {
+                    map.put(key, value);
+                }
             }
         }
         log.debug("OdooUtils: Converted object {} to map {}", object.getClass().getName(), map);

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/handlers/odoo/CompanyHandler.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/handlers/odoo/CompanyHandler.java
@@ -14,6 +14,7 @@ import com.ozonehis.eip.odoo.openmrs.client.OdooClient;
 import java.util.Map;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.r4.model.Encounter;
 import org.openmrs.eip.EIPException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -53,5 +54,37 @@ public class CompanyHandler {
         }
         throw new EIPException(
                 String.format("Unexpected res_id type returned for res.company external id %s: %s", externalId, resId));
+    }
+
+    public Integer getCompanyIdByEncounterLocation(Encounter encounter) {
+        String locationUuid = resolveEncounterLocationUuid(encounter);
+        if (locationUuid == null) {
+            log.warn("Encounter {} has no location reference", encounter == null ? null : encounter.getIdPart());
+            return null;
+        }
+        Integer companyId = getCompanyIdByExternalId(locationUuid);
+        if (companyId == null) {
+            log.warn(
+                    "No res.company external id matches location uuid {} for encounter {}",
+                    locationUuid,
+                    encounter.getIdPart());
+            return null;
+        }
+        return companyId;
+    }
+
+    private String resolveEncounterLocationUuid(Encounter encounter) {
+        if (encounter == null || !encounter.hasLocation()) {
+            return null;
+        }
+        String uuid = encounter
+                .getLocationFirstRep()
+                .getLocation()
+                .getReferenceElement()
+                .getIdPart();
+        if (uuid == null || uuid.isBlank()) {
+            return null;
+        }
+        return uuid.trim();
     }
 }

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/handlers/odoo/CompanyHandler.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/handlers/odoo/CompanyHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2021, Ozone HIS <info@ozone-his.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.ozonehis.eip.odoo.openmrs.handlers.odoo;
+
+import static java.util.Arrays.asList;
+
+import com.ozonehis.eip.odoo.openmrs.Constants;
+import com.ozonehis.eip.odoo.openmrs.client.OdooClient;
+import java.util.List;
+import java.util.Map;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.openmrs.eip.EIPException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Setter
+@Component
+public class CompanyHandler {
+
+    @Autowired
+    private OdooClient odooClient;
+
+    public Integer getCompanyIdByName(String name) {
+        if (name == null || name.isBlank()) {
+            return null;
+        }
+        Object[] records = odooClient.searchAndRead(
+                Constants.COMPANY_MODEL, List.of(asList("name", "=", name)), List.of("id", "name"));
+        if (records == null) {
+            throw new EIPException(
+                    String.format("Got null response while fetching for res.company with name %s", name));
+        } else if (records.length == 0) {
+            log.warn("No res.company found with name {}", name);
+            return null;
+        } else if (records.length > 1) {
+            log.warn("Multiple res.company found with name {}", name);
+            throw new EIPException(String.format("Multiple res.company found with name %s", name));
+        }
+        Object id = ((Map<String, Object>) records[0]).get("id");
+        if (id instanceof Integer) {
+            return (Integer) id;
+        }
+        if (id instanceof Number) {
+            return ((Number) id).intValue();
+        }
+        throw new EIPException(String.format("Unexpected id type returned for res.company name %s: %s", name, id));
+    }
+}

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/handlers/odoo/CompanyHandler.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/handlers/odoo/CompanyHandler.java
@@ -11,7 +11,6 @@ import static java.util.Arrays.asList;
 
 import com.ozonehis.eip.odoo.openmrs.Constants;
 import com.ozonehis.eip.odoo.openmrs.client.OdooClient;
-import java.util.List;
 import java.util.Map;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -27,29 +26,32 @@ public class CompanyHandler {
     @Autowired
     private OdooClient odooClient;
 
-    public Integer getCompanyIdByName(String name) {
-        if (name == null || name.isBlank()) {
+    public Integer getCompanyIdByExternalId(String externalId) {
+        if (externalId == null || externalId.isBlank()) {
             return null;
         }
         Object[] records = odooClient.searchAndRead(
-                Constants.COMPANY_MODEL, List.of(asList("name", "=", name)), List.of("id", "name"));
+                Constants.IR_MODEL,
+                asList(asList("model", "=", Constants.COMPANY_MODEL), asList("name", "=", externalId)),
+                asList("res_id"));
         if (records == null) {
             throw new EIPException(
-                    String.format("Got null response while fetching for res.company with name %s", name));
+                    String.format("Got null response while fetching for res.company with external id %s", externalId));
         } else if (records.length == 0) {
-            log.warn("No res.company found with name {}", name);
+            log.warn("No res.company found with external id {}", externalId);
             return null;
         } else if (records.length > 1) {
-            log.warn("Multiple res.company found with name {}", name);
-            throw new EIPException(String.format("Multiple res.company found with name %s", name));
+            log.warn("Multiple res.company external id mappings found for {}", externalId);
+            throw new EIPException(String.format("Multiple res.company external id mappings found for %s", externalId));
         }
-        Object id = ((Map<String, Object>) records[0]).get("id");
-        if (id instanceof Integer) {
-            return (Integer) id;
+        Object resId = ((Map<String, Object>) records[0]).get("res_id");
+        if (resId instanceof Integer) {
+            return (Integer) resId;
         }
-        if (id instanceof Number) {
-            return ((Number) id).intValue();
+        if (resId instanceof Number) {
+            return ((Number) resId).intValue();
         }
-        throw new EIPException(String.format("Unexpected id type returned for res.company name %s: %s", name, id));
+        throw new EIPException(
+                String.format("Unexpected res_id type returned for res.company external id %s: %s", externalId, resId));
     }
 }

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/handlers/odoo/PartnerHandler.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/handlers/odoo/PartnerHandler.java
@@ -78,10 +78,6 @@ public class PartnerHandler {
         }
     }
 
-    public Partner createOrUpdatePartner(ProducerTemplate producerTemplate, Patient patient) {
-        return createOrUpdatePartner(producerTemplate, patient, null);
-    }
-
     public Partner createOrUpdatePartner(ProducerTemplate producerTemplate, Patient patient, Integer companyId) {
         Partner fetchedPartner = getPartnerByID(patient.getIdPart());
         if (fetchedPartner != null && fetchedPartner.getPartnerId() > 0) {

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/handlers/odoo/PartnerHandler.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/handlers/odoo/PartnerHandler.java
@@ -79,17 +79,23 @@ public class PartnerHandler {
     }
 
     public Partner createOrUpdatePartner(ProducerTemplate producerTemplate, Patient patient) {
+        return createOrUpdatePartner(producerTemplate, patient, null);
+    }
+
+    public Partner createOrUpdatePartner(ProducerTemplate producerTemplate, Patient patient, Integer companyId) {
         Partner fetchedPartner = getPartnerByID(patient.getIdPart());
         if (fetchedPartner != null && fetchedPartner.getPartnerId() > 0) {
             int partnerId = fetchedPartner.getPartnerId();
             log.info("Partner with reference id {} already exists, updating...", patient.getIdPart());
             Partner partner = partnerMapper.toOdoo(patient);
             partner.setPartnerId(partnerId);
+            partner.setPartnerCompanyId(companyId);
             sendPartner(producerTemplate, "direct:odoo-update-partner-route", partner);
             return getPartnerByID(partner.getPartnerRef());
         } else {
             log.info("Partner with reference id {} does not exist, creating...", patient.getIdPart());
             Partner partner = partnerMapper.toOdoo(patient);
+            partner.setPartnerCompanyId(companyId);
             sendPartner(producerTemplate, "direct:odoo-create-partner-route", partner);
             return getPartnerByID(partner.getPartnerRef());
         }

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/handlers/odoo/SaleOrderHandler.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/handlers/odoo/SaleOrderHandler.java
@@ -70,10 +70,6 @@ public class SaleOrderHandler {
 
     public List<String> orderDefaultAttributes;
 
-    public SaleOrder getDraftSaleOrderIfExistsByVisitId(String visitId) {
-        return getDraftSaleOrderIfExistsByVisitId(visitId, null);
-    }
-
     public SaleOrder getDraftSaleOrderIfExistsByVisitId(String visitId, Integer companyId) {
         orderDefaultAttributes = asList(
                 "id",
@@ -124,17 +120,6 @@ public class SaleOrderHandler {
             String encounterVisitUuid,
             int partnerId,
             String patientID,
-            ProducerTemplate producerTemplate) {
-        updateSaleOrderIfExistsWithSaleOrderLine(
-                resource, saleOrder, encounterVisitUuid, partnerId, patientID, null, producerTemplate);
-    }
-
-    public void updateSaleOrderIfExistsWithSaleOrderLine(
-            Resource resource,
-            SaleOrder saleOrder,
-            String encounterVisitUuid,
-            int partnerId,
-            String patientID,
             Integer companyId,
             ProducerTemplate producerTemplate) {
         // If sale order exists create sale order line and link it to sale order
@@ -160,17 +145,6 @@ public class SaleOrderHandler {
                 resource.getClass().getName(),
                 saleOrderLine,
                 saleOrder);
-    }
-
-    public void createSaleOrderWithSaleOrderLine(
-            Resource resource,
-            Encounter encounter,
-            Partner partner,
-            String encounterVisitUuid,
-            String patientID,
-            ProducerTemplate producerTemplate) {
-        createSaleOrderWithSaleOrderLine(
-                resource, encounter, partner, encounterVisitUuid, patientID, null, producerTemplate);
     }
 
     public void createSaleOrderWithSaleOrderLine(
@@ -221,10 +195,6 @@ public class SaleOrderHandler {
         }
     }
 
-    public void deleteSaleOrderLine(Resource resource, String encounterVisitUuid, ProducerTemplate producerTemplate) {
-        deleteSaleOrderLine(resource, encounterVisitUuid, null, producerTemplate);
-    }
-
     public void deleteSaleOrderLine(
             Resource resource, String encounterVisitUuid, Integer companyId, ProducerTemplate producerTemplate) {
         SaleOrder saleOrder = getDraftSaleOrderIfExistsByVisitId(encounterVisitUuid, companyId);
@@ -242,11 +212,6 @@ public class SaleOrderHandler {
     }
 
     // Check if sale order has no sale order line, then cancel the sale order
-    public void cancelSaleOrderWhenNoSaleOrderLine(
-            int partnerId, String encounterVisitUuid, ProducerTemplate producerTemplate) {
-        cancelSaleOrderWhenNoSaleOrderLine(partnerId, encounterVisitUuid, null, producerTemplate);
-    }
-
     public void cancelSaleOrderWhenNoSaleOrderLine(
             int partnerId, String encounterVisitUuid, Integer companyId, ProducerTemplate producerTemplate) {
         SaleOrder saleOrder = getDraftSaleOrderIfExistsByVisitId(encounterVisitUuid, companyId);

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/handlers/odoo/SaleOrderHandler.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/handlers/odoo/SaleOrderHandler.java
@@ -18,6 +18,7 @@ import com.ozonehis.eip.odoo.openmrs.model.Partner;
 import com.ozonehis.eip.odoo.openmrs.model.Product;
 import com.ozonehis.eip.odoo.openmrs.model.SaleOrder;
 import com.ozonehis.eip.odoo.openmrs.model.SaleOrderLine;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,19 +71,27 @@ public class SaleOrderHandler {
     public List<String> orderDefaultAttributes;
 
     public SaleOrder getDraftSaleOrderIfExistsByVisitId(String visitId) {
+        return getDraftSaleOrderIfExistsByVisitId(visitId, null);
+    }
+
+    public SaleOrder getDraftSaleOrderIfExistsByVisitId(String visitId, Integer companyId) {
         orderDefaultAttributes = asList(
                 "id",
                 "client_order_ref",
                 "partner_id",
                 "state",
                 "order_line",
+                "company_id",
                 odooCustomerWeightField,
                 odooCustomerDobField,
                 odooCustomerIdField);
-        Object[] records = odooClient.searchAndRead(
-                Constants.SALE_ORDER_MODEL,
-                List.of(asList("client_order_ref", "=", visitId), asList("state", "=", "draft")),
-                orderDefaultAttributes);
+        List<Object> criteria = new ArrayList<>();
+        criteria.add(asList("client_order_ref", "=", visitId));
+        criteria.add(asList("state", "=", "draft"));
+        if (companyId != null) {
+            criteria.add(asList("company_id", "=", companyId));
+        }
+        Object[] records = odooClient.searchAndRead(Constants.SALE_ORDER_MODEL, criteria, orderDefaultAttributes);
         if (records == null) {
             throw new EIPException(
                     String.format("Got null response while fetching for Sale order with client_order_ref %s", visitId));
@@ -116,6 +125,18 @@ public class SaleOrderHandler {
             int partnerId,
             String patientID,
             ProducerTemplate producerTemplate) {
+        updateSaleOrderIfExistsWithSaleOrderLine(
+                resource, saleOrder, encounterVisitUuid, partnerId, patientID, null, producerTemplate);
+    }
+
+    public void updateSaleOrderIfExistsWithSaleOrderLine(
+            Resource resource,
+            SaleOrder saleOrder,
+            String encounterVisitUuid,
+            int partnerId,
+            String patientID,
+            Integer companyId,
+            ProducerTemplate producerTemplate) {
         // If sale order exists create sale order line and link it to sale order
         SaleOrderLine saleOrderLine = saleOrderLineHandler.buildSaleOrderLineIfProductExists(resource, saleOrder);
         if (saleOrderLine == null) {
@@ -125,6 +146,7 @@ public class SaleOrderHandler {
                     encounterVisitUuid);
             return;
         }
+        saleOrderLine.setSaleOrderLineCompanyId(companyId);
 
         // Update sale order with Patient Weight if not already present
         if (saleOrder.getPartnerWeight() == null
@@ -147,10 +169,23 @@ public class SaleOrderHandler {
             String encounterVisitUuid,
             String patientID,
             ProducerTemplate producerTemplate) {
+        createSaleOrderWithSaleOrderLine(
+                resource, encounter, partner, encounterVisitUuid, patientID, null, producerTemplate);
+    }
+
+    public void createSaleOrderWithSaleOrderLine(
+            Resource resource,
+            Encounter encounter,
+            Partner partner,
+            String encounterVisitUuid,
+            String patientID,
+            Integer companyId,
+            ProducerTemplate producerTemplate) {
         // If the sale order does not exist, create it, then create sale order line and link it to sale order
         SaleOrder newSaleOrder = saleOrderMapper.toOdoo(encounter);
         newSaleOrder.setOrderPartnerId(partner.getPartnerId());
         newSaleOrder.setOrderState("draft");
+        newSaleOrder.setCompanyId(companyId);
         // Add Patient DOB to Odoo Quotation
         newSaleOrder.setPartnerBirthDate(partner.getPartnerBirthDate());
         // Add Patient Id to Odoo Quotation
@@ -164,7 +199,7 @@ public class SaleOrderHandler {
         log.debug(
                 "{}: Created sale order with partner_id {}", resource.getClass().getName(), partner.getPartnerId());
 
-        SaleOrder fetchedSaleOrder = getDraftSaleOrderIfExistsByVisitId(encounterVisitUuid);
+        SaleOrder fetchedSaleOrder = getDraftSaleOrderIfExistsByVisitId(encounterVisitUuid, companyId);
         if (fetchedSaleOrder != null) {
             SaleOrderLine saleOrderLine =
                     saleOrderLineHandler.buildSaleOrderLineIfProductExists(resource, fetchedSaleOrder);
@@ -175,6 +210,7 @@ public class SaleOrderHandler {
                         partner.getPartnerId());
                 return;
             }
+            saleOrderLine.setSaleOrderLineCompanyId(companyId);
 
             producerTemplate.sendBody("direct:odoo-create-sale-order-line-route", saleOrderLine);
             log.debug(
@@ -186,7 +222,12 @@ public class SaleOrderHandler {
     }
 
     public void deleteSaleOrderLine(Resource resource, String encounterVisitUuid, ProducerTemplate producerTemplate) {
-        SaleOrder saleOrder = getDraftSaleOrderIfExistsByVisitId(encounterVisitUuid);
+        deleteSaleOrderLine(resource, encounterVisitUuid, null, producerTemplate);
+    }
+
+    public void deleteSaleOrderLine(
+            Resource resource, String encounterVisitUuid, Integer companyId, ProducerTemplate producerTemplate) {
+        SaleOrder saleOrder = getDraftSaleOrderIfExistsByVisitId(encounterVisitUuid, companyId);
         if (saleOrder != null) {
             Product product = productHandler.getProduct(resource);
             if (product != null) {
@@ -203,7 +244,12 @@ public class SaleOrderHandler {
     // Check if sale order has no sale order line, then cancel the sale order
     public void cancelSaleOrderWhenNoSaleOrderLine(
             int partnerId, String encounterVisitUuid, ProducerTemplate producerTemplate) {
-        SaleOrder saleOrder = getDraftSaleOrderIfExistsByVisitId(encounterVisitUuid);
+        cancelSaleOrderWhenNoSaleOrderLine(partnerId, encounterVisitUuid, null, producerTemplate);
+    }
+
+    public void cancelSaleOrderWhenNoSaleOrderLine(
+            int partnerId, String encounterVisitUuid, Integer companyId, ProducerTemplate producerTemplate) {
+        SaleOrder saleOrder = getDraftSaleOrderIfExistsByVisitId(encounterVisitUuid, companyId);
         if (saleOrder != null
                 && (saleOrder.getOrderLine() == null || saleOrder.getOrderLine().isEmpty())) {
             log.debug("SaleOrderHandler: Count of sale order line {}", saleOrder.getOrderLine());

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/model/Partner.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/model/Partner.java
@@ -60,4 +60,7 @@ public class Partner implements OdooResource {
 
     @JsonProperty("odoo.customer.id.field")
     private String partnerExternalId;
+
+    @JsonProperty("company_id")
+    private Object partnerCompanyId; // Can be Integer on write, [id, name] list on read
 }

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/model/SaleOrder.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/model/SaleOrder.java
@@ -46,4 +46,7 @@ public class SaleOrder implements OdooResource {
 
     @JsonProperty("odoo.customer.id.field")
     private String odooCustomerId;
+
+    @JsonProperty("company_id")
+    private Object companyId; // Can be Integer on write, [id, name] list on read
 }

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/model/SaleOrderLine.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/model/SaleOrderLine.java
@@ -36,4 +36,7 @@ public class SaleOrderLine implements OdooResource {
 
     @JsonProperty("product_uom")
     private Object saleOrderLineProductUom; // Can be used as a list or Integer, Stores code of product or product name
+
+    @JsonProperty("company_id")
+    private Object saleOrderLineCompanyId; // Can be Integer on write, [id, name] list on read
 }

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/EncounterProcessor.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/EncounterProcessor.java
@@ -34,7 +34,7 @@ public class EncounterProcessor implements Processor {
         Encounter encounter = message.getBody(Encounter.class);
         if (encounter != null && encounter.hasPeriod() && encounter.getPeriod().hasEnd()) {
             String encounterVisitUuid = encounter.getIdPart(); // TODO: Check if this should be referenceId
-            SaleOrder saleOrder = saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(encounterVisitUuid);
+            SaleOrder saleOrder = saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(encounterVisitUuid, null);
             if (saleOrder != null) {
                 Map<String, Object> headers = new HashMap<>();
                 // Check if Sale Order needs to be moved from `draft` state to `sale` state

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/MedicationRequestProcessor.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/MedicationRequestProcessor.java
@@ -35,8 +35,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class MedicationRequestProcessor implements Processor {
 
-    @Value("${bahmni.multi.company.enabled:false}")
-    private boolean bahmniMultiCompanyEnabled;
+    @Value("${enable.encounter.location.company.mapping:false}")
+    private boolean enableEncounterLocationCompanyMapping;
 
     @Autowired
     private SaleOrderHandler saleOrderHandler;
@@ -84,20 +84,10 @@ public class MedicationRequestProcessor implements Processor {
                 String encounterVisitUuid = encounter.getPartOf().getReference().split("/")[1];
 
                 Integer companyId = null;
-                if (bahmniMultiCompanyEnabled) {
-                    String locationDisplay = resolveEncounterLocationDisplay(encounter);
-                    if (locationDisplay == null) {
-                        log.info(
-                                "Bahmni multi-company: skipping MedicationRequest sync — encounter {} has no location display",
-                                encounter.getIdPart());
-                        return;
-                    }
-                    companyId = companyHandler.getCompanyIdByName(locationDisplay);
+                if (enableEncounterLocationCompanyMapping) {
+                    companyId = getCompanyIdByEncounterLocationUuid(encounter);
                     if (companyId == null) {
-                        log.info(
-                                "Bahmni multi-company: skipping MedicationRequest sync — no res.company matches location display '{}' for encounter {}",
-                                locationDisplay,
-                                encounter.getIdPart());
+                        log.warn("Skipping MedicationRequest sync as company id is null for MedicationRequest id {}", medicationRequest.getIdPart());
                         return;
                     }
                 }
@@ -146,14 +136,32 @@ public class MedicationRequestProcessor implements Processor {
         }
     }
 
-    private String resolveEncounterLocationDisplay(Encounter encounter) {
+    private Integer getCompanyIdByEncounterLocationUuid(Encounter encounter) {
+        String locationUuid = resolveEncounterLocationUuid(encounter);
+        if (locationUuid == null) {
+            log.warn("Encounter {} has no location reference", encounter.getIdPart());
+            return null;
+        }
+        Integer companyId = companyHandler.getCompanyIdByExternalId(locationUuid);
+        if (companyId == null) {
+            log.warn("No res.company external id matches location uuid {} for encounter {}", locationUuid, encounter.getIdPart());
+            return null;
+        }
+        return companyId;
+    }
+
+    private String resolveEncounterLocationUuid(Encounter encounter) {
         if (encounter == null || !encounter.hasLocation()) {
             return null;
         }
-        String display = encounter.getLocationFirstRep().getLocation().getDisplay();
-        if (display == null || display.isBlank()) {
+        String uuid = encounter
+                .getLocationFirstRep()
+                .getLocation()
+                .getReferenceElement()
+                .getIdPart();
+        if (uuid == null || uuid.isBlank()) {
             return null;
         }
-        return display.trim();
+        return uuid.trim();
     }
 }

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/MedicationRequestProcessor.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/MedicationRequestProcessor.java
@@ -7,6 +7,7 @@
  */
 package com.ozonehis.eip.odoo.openmrs.processors;
 
+import com.ozonehis.eip.odoo.openmrs.handlers.odoo.CompanyHandler;
 import com.ozonehis.eip.odoo.openmrs.handlers.odoo.PartnerHandler;
 import com.ozonehis.eip.odoo.openmrs.handlers.odoo.SaleOrderHandler;
 import com.ozonehis.eip.odoo.openmrs.model.Partner;
@@ -26,6 +27,7 @@ import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Resource;
 import org.openmrs.eip.fhir.Constants;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -33,11 +35,17 @@ import org.springframework.stereotype.Component;
 @Component
 public class MedicationRequestProcessor implements Processor {
 
+    @Value("${bahmni.multi.company.enabled:false}")
+    private boolean bahmniMultiCompanyEnabled;
+
     @Autowired
     private SaleOrderHandler saleOrderHandler;
 
     @Autowired
     private PartnerHandler partnerHandler;
+
+    @Autowired
+    private CompanyHandler companyHandler;
 
     @Override
     public void process(Exchange exchange) {
@@ -74,10 +82,31 @@ public class MedicationRequestProcessor implements Processor {
                     throw new IllegalArgumentException("Event type not found in the exchange headers.");
                 }
                 String encounterVisitUuid = encounter.getPartOf().getReference().split("/")[1];
-                Partner partner = partnerHandler.createOrUpdatePartner(producerTemplate, patient);
+
+                Integer companyId = null;
+                if (bahmniMultiCompanyEnabled) {
+                    String locationDisplay = resolveEncounterLocationDisplay(encounter);
+                    if (locationDisplay == null) {
+                        log.info(
+                                "Bahmni multi-company: skipping MedicationRequest sync — encounter {} has no location display",
+                                encounter.getIdPart());
+                        return;
+                    }
+                    companyId = companyHandler.getCompanyIdByName(locationDisplay);
+                    if (companyId == null) {
+                        log.info(
+                                "Bahmni multi-company: skipping MedicationRequest sync — no res.company matches location display '{}' for encounter {}",
+                                locationDisplay,
+                                encounter.getIdPart());
+                        return;
+                    }
+                }
+
+                Partner partner = partnerHandler.createOrUpdatePartner(producerTemplate, patient, companyId);
                 if ("c".equals(eventType) || "u".equals(eventType)) {
                     if (!medicationRequest.getStatus().equals(MedicationRequest.MedicationRequestStatus.CANCELLED)) {
-                        SaleOrder saleOrder = saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(encounterVisitUuid);
+                        SaleOrder saleOrder =
+                                saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(encounterVisitUuid, companyId);
                         if (saleOrder != null) {
                             saleOrderHandler.updateSaleOrderIfExistsWithSaleOrderLine(
                                     medicationRequest,
@@ -85,6 +114,7 @@ public class MedicationRequestProcessor implements Processor {
                                     encounterVisitUuid,
                                     partner.getPartnerId(),
                                     patient.getIdPart(),
+                                    companyId,
                                     producerTemplate);
                         } else {
                             saleOrderHandler.createSaleOrderWithSaleOrderLine(
@@ -93,17 +123,20 @@ public class MedicationRequestProcessor implements Processor {
                                     partner,
                                     encounterVisitUuid,
                                     patient.getIdPart(),
+                                    companyId,
                                     producerTemplate);
                         }
                     } else {
                         // Executed when MODIFY option is selected in OpenMRS
-                        saleOrderHandler.deleteSaleOrderLine(medicationRequest, encounterVisitUuid, producerTemplate);
+                        saleOrderHandler.deleteSaleOrderLine(
+                                medicationRequest, encounterVisitUuid, companyId, producerTemplate);
                     }
                 } else if ("d".equals(eventType)) {
                     // Executed when DISCONTINUE option is selected in OpenMRS
-                    saleOrderHandler.deleteSaleOrderLine(medicationRequest, encounterVisitUuid, producerTemplate);
+                    saleOrderHandler.deleteSaleOrderLine(
+                            medicationRequest, encounterVisitUuid, companyId, producerTemplate);
                     saleOrderHandler.cancelSaleOrderWhenNoSaleOrderLine(
-                            partner.getPartnerId(), encounterVisitUuid, producerTemplate);
+                            partner.getPartnerId(), encounterVisitUuid, companyId, producerTemplate);
                 } else {
                     throw new IllegalArgumentException("Unsupported event type: " + eventType);
                 }
@@ -111,5 +144,16 @@ public class MedicationRequestProcessor implements Processor {
         } catch (Exception e) {
             throw new CamelExecutionException("Error processing MedicationRequest", exchange, e);
         }
+    }
+
+    private String resolveEncounterLocationDisplay(Encounter encounter) {
+        if (encounter == null || !encounter.hasLocation()) {
+            return null;
+        }
+        String display = encounter.getLocationFirstRep().getLocation().getDisplay();
+        if (display == null || display.isBlank()) {
+            return null;
+        }
+        return display.trim();
     }
 }

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/MedicationRequestProcessor.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/MedicationRequestProcessor.java
@@ -35,7 +35,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class MedicationRequestProcessor implements Processor {
 
-    @Value("${enable.encounter.location.company.mapping:false}")
+    @Value("${enable.encounter.location.to.company.mapping:false}")
     private boolean enableEncounterLocationCompanyMapping;
 
     @Autowired

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/MedicationRequestProcessor.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/MedicationRequestProcessor.java
@@ -87,7 +87,9 @@ public class MedicationRequestProcessor implements Processor {
                 if (enableEncounterLocationCompanyMapping) {
                     companyId = getCompanyIdByEncounterLocationUuid(encounter);
                     if (companyId == null) {
-                        log.warn("Skipping MedicationRequest sync as company id is null for MedicationRequest id {}", medicationRequest.getIdPart());
+                        log.warn(
+                                "Skipping MedicationRequest sync as company id is null for MedicationRequest id {}",
+                                medicationRequest.getIdPart());
                         return;
                     }
                 }
@@ -144,7 +146,10 @@ public class MedicationRequestProcessor implements Processor {
         }
         Integer companyId = companyHandler.getCompanyIdByExternalId(locationUuid);
         if (companyId == null) {
-            log.warn("No res.company external id matches location uuid {} for encounter {}", locationUuid, encounter.getIdPart());
+            log.warn(
+                    "No res.company external id matches location uuid {} for encounter {}",
+                    locationUuid,
+                    encounter.getIdPart());
             return null;
         }
         return companyId;

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/MedicationRequestProcessor.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/MedicationRequestProcessor.java
@@ -85,7 +85,7 @@ public class MedicationRequestProcessor implements Processor {
 
                 Integer companyId = null;
                 if (enableEncounterLocationCompanyMapping) {
-                    companyId = getCompanyIdByEncounterLocationUuid(encounter);
+                    companyId = companyHandler.getCompanyIdByEncounterLocation(encounter);
                     if (companyId == null) {
                         log.warn(
                                 "Skipping MedicationRequest sync as company id is null for MedicationRequest id {}",
@@ -136,37 +136,5 @@ public class MedicationRequestProcessor implements Processor {
         } catch (Exception e) {
             throw new CamelExecutionException("Error processing MedicationRequest", exchange, e);
         }
-    }
-
-    private Integer getCompanyIdByEncounterLocationUuid(Encounter encounter) {
-        String locationUuid = resolveEncounterLocationUuid(encounter);
-        if (locationUuid == null) {
-            log.warn("Encounter {} has no location reference", encounter.getIdPart());
-            return null;
-        }
-        Integer companyId = companyHandler.getCompanyIdByExternalId(locationUuid);
-        if (companyId == null) {
-            log.warn(
-                    "No res.company external id matches location uuid {} for encounter {}",
-                    locationUuid,
-                    encounter.getIdPart());
-            return null;
-        }
-        return companyId;
-    }
-
-    private String resolveEncounterLocationUuid(Encounter encounter) {
-        if (encounter == null || !encounter.hasLocation()) {
-            return null;
-        }
-        String uuid = encounter
-                .getLocationFirstRep()
-                .getLocation()
-                .getReferenceElement()
-                .getIdPart();
-        if (uuid == null || uuid.isBlank()) {
-            return null;
-        }
-        return uuid.trim();
     }
 }

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/ServiceRequestProcessor.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/ServiceRequestProcessor.java
@@ -100,7 +100,9 @@ public class ServiceRequestProcessor implements Processor {
                 if (enableEncounterLocationCompanyMapping) {
                     companyId = getCompanyIdByEncounterLocationUuid(encounter);
                     if (companyId == null) {
-                        log.warn("Skipping ServiceRequest sync as company id is null for ServiceRequest id {}", serviceRequest.getIdPart());
+                        log.warn(
+                                "Skipping ServiceRequest sync as company id is null for ServiceRequest id {}",
+                                serviceRequest.getIdPart());
                         return;
                     }
                 }
@@ -179,7 +181,10 @@ public class ServiceRequestProcessor implements Processor {
         }
         Integer companyId = companyHandler.getCompanyIdByExternalId(locationUuid);
         if (companyId == null) {
-            log.warn("No res.company external id matches location uuid {} for encounter {}", locationUuid, encounter.getIdPart());
+            log.warn(
+                    "No res.company external id matches location uuid {} for encounter {}",
+                    locationUuid,
+                    encounter.getIdPart());
             return null;
         }
         return companyId;

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/ServiceRequestProcessor.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/ServiceRequestProcessor.java
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class ServiceRequestProcessor implements Processor {
 
-    @Value("${enable.encounter.location.company.mapping:false}")
+    @Value("${enable.encounter.location.to.company.mapping:false}")
     private boolean enableEncounterLocationCompanyMapping;
 
     @Autowired

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/ServiceRequestProcessor.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/ServiceRequestProcessor.java
@@ -7,6 +7,7 @@
  */
 package com.ozonehis.eip.odoo.openmrs.processors;
 
+import com.ozonehis.eip.odoo.openmrs.handlers.odoo.CompanyHandler;
 import com.ozonehis.eip.odoo.openmrs.handlers.odoo.PartnerHandler;
 import com.ozonehis.eip.odoo.openmrs.handlers.odoo.SaleOrderHandler;
 import com.ozonehis.eip.odoo.openmrs.handlers.openmrs.EncounterHandler;
@@ -27,12 +28,16 @@ import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ServiceRequest;
 import org.openmrs.eip.fhir.Constants;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Setter
 @Component
 public class ServiceRequestProcessor implements Processor {
+
+    @Value("${bahmni.multi.company.enabled:false}")
+    private boolean bahmniMultiCompanyEnabled;
 
     @Autowired
     private SaleOrderHandler saleOrderHandler;
@@ -45,6 +50,9 @@ public class ServiceRequestProcessor implements Processor {
 
     @Autowired
     private EncounterHandler encounterHandler;
+
+    @Autowired
+    private CompanyHandler companyHandler;
 
     @Override
     public void process(Exchange exchange) {
@@ -87,7 +95,27 @@ public class ServiceRequestProcessor implements Processor {
                     throw new IllegalArgumentException("Event type not found in the exchange headers.");
                 }
                 String encounterVisitUuid = encounter.getPartOf().getReference().split("/")[1];
-                Partner partner = partnerHandler.createOrUpdatePartner(producerTemplate, patient);
+
+                Integer companyId = null;
+                if (bahmniMultiCompanyEnabled) {
+                    String locationDisplay = resolveEncounterLocationDisplay(encounter);
+                    if (locationDisplay == null) {
+                        log.info(
+                                "Bahmni multi-company: skipping ServiceRequest sync — encounter {} has no location display",
+                                encounter.getIdPart());
+                        return;
+                    }
+                    companyId = companyHandler.getCompanyIdByName(locationDisplay);
+                    if (companyId == null) {
+                        log.info(
+                                "Bahmni multi-company: skipping ServiceRequest sync — no res.company matches location display '{}' for encounter {}",
+                                locationDisplay,
+                                encounter.getIdPart());
+                        return;
+                    }
+                }
+
+                Partner partner = partnerHandler.createOrUpdatePartner(producerTemplate, patient, companyId);
                 if ("c".equals(eventType) || "u".equals(eventType)) {
                     boolean isOrderIntent =
                             serviceRequest.getIntent().equals(ServiceRequest.ServiceRequestIntent.ORDER);
@@ -97,7 +125,8 @@ public class ServiceRequestProcessor implements Processor {
                             serviceRequest.getStatus().equals(ServiceRequest.ServiceRequestStatus.COMPLETED);
 
                     if (isOrderIntent) {
-                        SaleOrder saleOrder = saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(encounterVisitUuid);
+                        SaleOrder saleOrder =
+                                saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(encounterVisitUuid, companyId);
                         if (isActiveStatus || ("u".equals(eventType) && isCompletedStatus)) {
                             if (saleOrder != null) {
                                 saleOrderHandler.updateSaleOrderIfExistsWithSaleOrderLine(
@@ -106,6 +135,7 @@ public class ServiceRequestProcessor implements Processor {
                                         encounterVisitUuid,
                                         partner.getPartnerId(),
                                         patient.getIdPart(),
+                                        companyId,
                                         producerTemplate);
                             } else {
                                 saleOrderHandler.createSaleOrderWithSaleOrderLine(
@@ -114,15 +144,18 @@ public class ServiceRequestProcessor implements Processor {
                                         partner,
                                         encounterVisitUuid,
                                         patient.getIdPart(),
+                                        companyId,
                                         producerTemplate);
                             }
                         } else {
                             // Executed when MODIFY option is selected in OpenMRS for other statuses
-                            saleOrderHandler.deleteSaleOrderLine(serviceRequest, encounterVisitUuid, producerTemplate);
+                            saleOrderHandler.deleteSaleOrderLine(
+                                    serviceRequest, encounterVisitUuid, companyId, producerTemplate);
                         }
                     } else {
                         // Executed when MODIFY option is selected in OpenMRS
-                        saleOrderHandler.deleteSaleOrderLine(serviceRequest, encounterVisitUuid, producerTemplate);
+                        saleOrderHandler.deleteSaleOrderLine(
+                                serviceRequest, encounterVisitUuid, companyId, producerTemplate);
                     }
                 } else if ("d".equals(eventType)) {
                     // Executed when a DISCONTINUE option is selected in OpenMRS
@@ -134,9 +167,10 @@ public class ServiceRequestProcessor implements Processor {
                                 serviceRequest.getIdPart(),
                                 serviceRequest.getStatus());
                     } else {
-                        saleOrderHandler.deleteSaleOrderLine(serviceRequest, encounterVisitUuid, producerTemplate);
+                        saleOrderHandler.deleteSaleOrderLine(
+                                serviceRequest, encounterVisitUuid, companyId, producerTemplate);
                         saleOrderHandler.cancelSaleOrderWhenNoSaleOrderLine(
-                                partner.getPartnerId(), encounterVisitUuid, producerTemplate);
+                                partner.getPartnerId(), encounterVisitUuid, companyId, producerTemplate);
                     }
                 } else {
                     throw new IllegalArgumentException("Unsupported event type: " + eventType);
@@ -145,5 +179,16 @@ public class ServiceRequestProcessor implements Processor {
         } catch (Exception e) {
             throw new CamelExecutionException("Error processing ServiceRequest", exchange, e);
         }
+    }
+
+    private String resolveEncounterLocationDisplay(Encounter encounter) {
+        if (encounter == null || !encounter.hasLocation()) {
+            return null;
+        }
+        String display = encounter.getLocationFirstRep().getLocation().getDisplay();
+        if (display == null || display.isBlank()) {
+            return null;
+        }
+        return display.trim();
     }
 }

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/ServiceRequestProcessor.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/ServiceRequestProcessor.java
@@ -98,7 +98,7 @@ public class ServiceRequestProcessor implements Processor {
 
                 Integer companyId = null;
                 if (enableEncounterLocationCompanyMapping) {
-                    companyId = getCompanyIdByEncounterLocationUuid(encounter);
+                    companyId = companyHandler.getCompanyIdByEncounterLocation(encounter);
                     if (companyId == null) {
                         log.warn(
                                 "Skipping ServiceRequest sync as company id is null for ServiceRequest id {}",
@@ -171,37 +171,5 @@ public class ServiceRequestProcessor implements Processor {
         } catch (Exception e) {
             throw new CamelExecutionException("Error processing ServiceRequest", exchange, e);
         }
-    }
-
-    private Integer getCompanyIdByEncounterLocationUuid(Encounter encounter) {
-        String locationUuid = resolveEncounterLocationUuid(encounter);
-        if (locationUuid == null) {
-            log.warn("Encounter {} has no location reference", encounter.getIdPart());
-            return null;
-        }
-        Integer companyId = companyHandler.getCompanyIdByExternalId(locationUuid);
-        if (companyId == null) {
-            log.warn(
-                    "No res.company external id matches location uuid {} for encounter {}",
-                    locationUuid,
-                    encounter.getIdPart());
-            return null;
-        }
-        return companyId;
-    }
-
-    private String resolveEncounterLocationUuid(Encounter encounter) {
-        if (encounter == null || !encounter.hasLocation()) {
-            return null;
-        }
-        String uuid = encounter
-                .getLocationFirstRep()
-                .getLocation()
-                .getReferenceElement()
-                .getIdPart();
-        if (uuid == null || uuid.isBlank()) {
-            return null;
-        }
-        return uuid.trim();
     }
 }

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/ServiceRequestProcessor.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/ServiceRequestProcessor.java
@@ -36,8 +36,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class ServiceRequestProcessor implements Processor {
 
-    @Value("${bahmni.multi.company.enabled:false}")
-    private boolean bahmniMultiCompanyEnabled;
+    @Value("${enable.encounter.location.company.mapping:false}")
+    private boolean enableEncounterLocationCompanyMapping;
 
     @Autowired
     private SaleOrderHandler saleOrderHandler;
@@ -97,20 +97,10 @@ public class ServiceRequestProcessor implements Processor {
                 String encounterVisitUuid = encounter.getPartOf().getReference().split("/")[1];
 
                 Integer companyId = null;
-                if (bahmniMultiCompanyEnabled) {
-                    String locationDisplay = resolveEncounterLocationDisplay(encounter);
-                    if (locationDisplay == null) {
-                        log.info(
-                                "Bahmni multi-company: skipping ServiceRequest sync — encounter {} has no location display",
-                                encounter.getIdPart());
-                        return;
-                    }
-                    companyId = companyHandler.getCompanyIdByName(locationDisplay);
+                if (enableEncounterLocationCompanyMapping) {
+                    companyId = getCompanyIdByEncounterLocationUuid(encounter);
                     if (companyId == null) {
-                        log.info(
-                                "Bahmni multi-company: skipping ServiceRequest sync — no res.company matches location display '{}' for encounter {}",
-                                locationDisplay,
-                                encounter.getIdPart());
+                        log.warn("Skipping ServiceRequest sync as company id is null for ServiceRequest id {}", serviceRequest.getIdPart());
                         return;
                     }
                 }
@@ -181,14 +171,32 @@ public class ServiceRequestProcessor implements Processor {
         }
     }
 
-    private String resolveEncounterLocationDisplay(Encounter encounter) {
+    private Integer getCompanyIdByEncounterLocationUuid(Encounter encounter) {
+        String locationUuid = resolveEncounterLocationUuid(encounter);
+        if (locationUuid == null) {
+            log.warn("Encounter {} has no location reference", encounter.getIdPart());
+            return null;
+        }
+        Integer companyId = companyHandler.getCompanyIdByExternalId(locationUuid);
+        if (companyId == null) {
+            log.warn("No res.company external id matches location uuid {} for encounter {}", locationUuid, encounter.getIdPart());
+            return null;
+        }
+        return companyId;
+    }
+
+    private String resolveEncounterLocationUuid(Encounter encounter) {
         if (encounter == null || !encounter.hasLocation()) {
             return null;
         }
-        String display = encounter.getLocationFirstRep().getLocation().getDisplay();
-        if (display == null || display.isBlank()) {
+        String uuid = encounter
+                .getLocationFirstRep()
+                .getLocation()
+                .getReferenceElement()
+                .getIdPart();
+        if (uuid == null || uuid.isBlank()) {
             return null;
         }
-        return display.trim();
+        return uuid.trim();
     }
 }

--- a/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/SupplyRequestProcessor.java
+++ b/odoo-openmrs/src/main/java/com/ozonehis/eip/odoo/openmrs/processors/SupplyRequestProcessor.java
@@ -88,10 +88,11 @@ public class SupplyRequestProcessor implements Processor {
                     throw new IllegalArgumentException("Event type not found in the exchange headers.");
                 }
                 String encounterVisitUuid = encounter.getPartOf().getReference().split("/")[1];
-                Partner partner = partnerHandler.createOrUpdatePartner(producerTemplate, patient);
+                Partner partner = partnerHandler.createOrUpdatePartner(producerTemplate, patient, null);
                 if ("c".equals(eventType) || "u".equals(eventType)) {
                     if (supplyRequest.getStatus().equals(SupplyRequest.SupplyRequestStatus.ACTIVE)) {
-                        SaleOrder saleOrder = saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(encounterVisitUuid);
+                        SaleOrder saleOrder =
+                                saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(encounterVisitUuid, null);
                         if (saleOrder != null) {
                             saleOrderHandler.updateSaleOrderIfExistsWithSaleOrderLine(
                                     supplyRequest,
@@ -99,6 +100,7 @@ public class SupplyRequestProcessor implements Processor {
                                     encounterVisitUuid,
                                     partner.getPartnerId(),
                                     patient.getIdPart(),
+                                    null,
                                     producerTemplate);
                         } else {
                             saleOrderHandler.createSaleOrderWithSaleOrderLine(
@@ -107,17 +109,18 @@ public class SupplyRequestProcessor implements Processor {
                                     partner,
                                     encounterVisitUuid,
                                     patient.getIdPart(),
+                                    null,
                                     producerTemplate);
                         }
                     } else {
                         // Executed when MODIFY option is selected in OpenMRS
-                        saleOrderHandler.deleteSaleOrderLine(supplyRequest, encounterVisitUuid, producerTemplate);
+                        saleOrderHandler.deleteSaleOrderLine(supplyRequest, encounterVisitUuid, null, producerTemplate);
                     }
                 } else if ("d".equals(eventType)) {
                     // Executed when DISCONTINUE option is selected in OpenMRS
-                    saleOrderHandler.deleteSaleOrderLine(supplyRequest, encounterVisitUuid, producerTemplate);
+                    saleOrderHandler.deleteSaleOrderLine(supplyRequest, encounterVisitUuid, null, producerTemplate);
                     saleOrderHandler.cancelSaleOrderWhenNoSaleOrderLine(
-                            partner.getPartnerId(), encounterVisitUuid, producerTemplate);
+                            partner.getPartnerId(), encounterVisitUuid, null, producerTemplate);
                 } else {
                     throw new IllegalArgumentException("Unsupported event type: " + eventType);
                 }

--- a/odoo-openmrs/src/main/resources/config/application.properties
+++ b/odoo-openmrs/src/main/resources/config/application.properties
@@ -238,4 +238,12 @@ eip.product.sync.delay=${EIP_PRODUCT_SYNC_DELAY:3600000}
 # /mkdocs-config-default-value:`x_external_identifier`
 # /mkdocs-end
 odoo.customer.id.field=${ODOO_CUSTOMER_ID_FIELD:x_external_identifier}
+
+# /mkdocs-config-name:`bahmni.multi.company.enabled`
+# /mkdocs-config-variable:`BAHMNI_MULTI_COMPANY_ENABLED`
+# /mkdocs-config-description:When true, MedicationRequest/ServiceRequest sync resolves the Odoo company from the visit (partOf) Encounter location display (e.g. H2, H3) and writes partner, sale order, and sale order line under that company. When the location is missing or no matching res.company exists, the sync is skipped.
+# /mkdocs-config-possible-values:`true` or `false`
+# /mkdocs-config-default-value:`false`
+# /mkdocs-end
+bahmni.multi.company.enabled=${BAHMNI_MULTI_COMPANY_ENABLED:true}
 # ----------------------------------------------------------------------------------------------------------------------

--- a/odoo-openmrs/src/main/resources/config/application.properties
+++ b/odoo-openmrs/src/main/resources/config/application.properties
@@ -239,11 +239,11 @@ eip.product.sync.delay=${EIP_PRODUCT_SYNC_DELAY:3600000}
 # /mkdocs-end
 odoo.customer.id.field=${ODOO_CUSTOMER_ID_FIELD:x_external_identifier}
 
-# /mkdocs-config-name:`bahmni.multi.company.enabled`
-# /mkdocs-config-variable:`BAHMNI_MULTI_COMPANY_ENABLED`
-# /mkdocs-config-description:When true, MedicationRequest/ServiceRequest sync resolves the Odoo company from the visit (partOf) Encounter location display (e.g. H2, H3) and writes partner, sale order, and sale order line under that company. When the location is missing or no matching res.company exists, the sync is skipped.
+# /mkdocs-config-name:`enable.encounter.location.company.mapping`
+# /mkdocs-config-variable:`ENABLE_ENCOUNTER_LOCATION_COMPANY_MAPPING`
+# /mkdocs-config-description:When true, MedicationRequest/ServiceRequest sync adds the Odoo company by looking at Encounter location.
 # /mkdocs-config-possible-values:`true` or `false`
 # /mkdocs-config-default-value:`false`
 # /mkdocs-end
-bahmni.multi.company.enabled=${BAHMNI_MULTI_COMPANY_ENABLED:true}
+enable.encounter.location.company.mapping=${ENABLE_ENCOUNTER_LOCATION_COMPANY_MAPPING:true}
 # ----------------------------------------------------------------------------------------------------------------------

--- a/odoo-openmrs/src/main/resources/config/application.properties
+++ b/odoo-openmrs/src/main/resources/config/application.properties
@@ -239,11 +239,11 @@ eip.product.sync.delay=${EIP_PRODUCT_SYNC_DELAY:3600000}
 # /mkdocs-end
 odoo.customer.id.field=${ODOO_CUSTOMER_ID_FIELD:x_external_identifier}
 
-# /mkdocs-config-name:`enable.encounter.location.company.mapping`
-# /mkdocs-config-variable:`ENABLE_ENCOUNTER_LOCATION_COMPANY_MAPPING`
+# /mkdocs-config-name:`enable.encounter.location.to.company.mapping`
+# /mkdocs-config-variable:`ENABLE_ENCOUNTER_LOCATION_TO_COMPANY_MAPPING`
 # /mkdocs-config-description:When true, MedicationRequest/ServiceRequest sync adds the Odoo company by looking at Encounter location.
 # /mkdocs-config-possible-values:`true` or `false`
 # /mkdocs-config-default-value:`false`
 # /mkdocs-end
-enable.encounter.location.company.mapping=${ENABLE_ENCOUNTER_LOCATION_COMPANY_MAPPING:true}
+enable.encounter.location.to.company.mapping=${ENABLE_ENCOUNTER_LOCATION_TO_COMPANY_MAPPING:false}
 # ----------------------------------------------------------------------------------------------------------------------

--- a/odoo-openmrs/src/test/java/com/ozonehis/eip/odoo/openmrs/client/OdooUtilsTest.java
+++ b/odoo-openmrs/src/test/java/com/ozonehis/eip/odoo/openmrs/client/OdooUtilsTest.java
@@ -8,10 +8,29 @@
 package com.ozonehis.eip.odoo.openmrs.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.when;
 
+import com.ozonehis.eip.odoo.openmrs.model.SaleOrder;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.core.env.Environment;
 
 class OdooUtilsTest {
+
+    private OdooUtils odooUtils;
+
+    @BeforeEach
+    void setup() {
+        Environment mockEnvironment = Mockito.mock(Environment.class);
+        when(mockEnvironment.getProperty("odoo.customer.weight.field")).thenReturn("x_customer_weight");
+        when(mockEnvironment.getProperty("odoo.customer.dob.field")).thenReturn("x_customer_dob");
+        when(mockEnvironment.getProperty("odoo.customer.id.field")).thenReturn("x_external_identifier");
+        odooUtils = new OdooUtils();
+        odooUtils.setEnvironment(mockEnvironment);
+    }
 
     @Test
     void shouldReturnDateInyyyy_MM_ddGivenDateInEEE_MMM_ddFormat() {
@@ -35,5 +54,22 @@ class OdooUtilsTest {
 
         // Verify
         assertEquals("", result);
+    }
+
+    @Test
+    void shouldExcludeNullFieldsWhenConvertingObjectToMap() throws Exception {
+        // Setup
+        SaleOrder saleOrder = new SaleOrder();
+        saleOrder.setOrderClientOrderRef("visit-123");
+        saleOrder.setOrderState("draft");
+
+        // Act
+        Map<String, Object> result = odooUtils.convertObjectToMap(saleOrder);
+
+        // Verify
+        assertEquals("visit-123", result.get("client_order_ref"));
+        assertEquals("draft", result.get("state"));
+        assertFalse(result.containsKey("company_id"));
+        assertFalse(result.containsKey("partner_id"));
     }
 }

--- a/odoo-openmrs/src/test/java/com/ozonehis/eip/odoo/openmrs/handlers/CompanyHandlerTest.java
+++ b/odoo-openmrs/src/test/java/com/ozonehis/eip/odoo/openmrs/handlers/CompanyHandlerTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright © 2021, Ozone HIS <info@ozone-his.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.ozonehis.eip.odoo.openmrs.handlers;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import com.ozonehis.eip.odoo.openmrs.Constants;
+import com.ozonehis.eip.odoo.openmrs.client.OdooClient;
+import com.ozonehis.eip.odoo.openmrs.handlers.odoo.CompanyHandler;
+import java.util.HashMap;
+import java.util.Map;
+import org.hl7.fhir.r4.model.Encounter;
+import org.hl7.fhir.r4.model.Reference;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.openmrs.eip.EIPException;
+
+class CompanyHandlerTest {
+
+    private static final String EXTERNAL_ID = "8d6c993e-c2cc-11de-8d13-0010c6dffd0f";
+
+    private static final String ENCOUNTER_UUID = "1cdda1ce-7f98-4bc7-9d20-8b4e953d972a";
+
+    @Mock
+    private OdooClient odooClient;
+
+    @InjectMocks
+    private CompanyHandler companyHandler;
+
+    private static AutoCloseable mocksCloser;
+
+    @AfterAll
+    public static void close() throws Exception {
+        mocksCloser.close();
+    }
+
+    @BeforeEach
+    public void setup() {
+        mocksCloser = openMocks(this);
+    }
+
+    @Test
+    public void shouldReturnCompanyIdWhenExternalIdHasOneMappingWithIntegerResId() {
+        // Setup
+        Object[] companies = {getCompanyExternalIdMap(12)};
+
+        // Mock behavior
+        when(odooClient.searchAndRead(
+                        Constants.IR_MODEL,
+                        asList(asList("model", "=", Constants.COMPANY_MODEL), asList("name", "=", EXTERNAL_ID)),
+                        asList("res_id")))
+                .thenReturn(companies);
+
+        // Act
+        Integer companyId = companyHandler.getCompanyIdByExternalId(EXTERNAL_ID);
+
+        // Verify
+        assertEquals(12, companyId);
+    }
+
+    @Test
+    public void shouldReturnCompanyIdWhenExternalIdHasOneMappingWithNumericResId() {
+        // Setup
+        Object[] companies = {getCompanyExternalIdMap(12.0)};
+
+        // Mock behavior
+        when(odooClient.searchAndRead(
+                        Constants.IR_MODEL,
+                        asList(asList("model", "=", Constants.COMPANY_MODEL), asList("name", "=", EXTERNAL_ID)),
+                        asList("res_id")))
+                .thenReturn(companies);
+
+        // Act
+        Integer companyId = companyHandler.getCompanyIdByExternalId(EXTERNAL_ID);
+
+        // Verify
+        assertEquals(12, companyId);
+    }
+
+    @Test
+    public void shouldReturnNullAndSkipOdooLookupWhenExternalIdIsBlank() {
+        // Act
+        Integer companyId = companyHandler.getCompanyIdByExternalId("");
+
+        // Verify
+        assertNull(companyId);
+        verify(odooClient, times(0)).searchAndRead(any(), any(), any());
+    }
+
+    @Test
+    public void shouldReturnNullWhenNoCompanyFoundWithExternalId() {
+        // Mock behavior
+        when(odooClient.searchAndRead(
+                        Constants.IR_MODEL,
+                        asList(asList("model", "=", Constants.COMPANY_MODEL), asList("name", "=", EXTERNAL_ID)),
+                        asList("res_id")))
+                .thenReturn(new Object[] {});
+
+        // Act
+        Integer companyId = companyHandler.getCompanyIdByExternalId(EXTERNAL_ID);
+
+        // Verify
+        assertNull(companyId);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenOdooReturnsNullForExternalIdLookup() {
+        // Mock behavior
+        when(odooClient.searchAndRead(
+                        Constants.IR_MODEL,
+                        asList(asList("model", "=", Constants.COMPANY_MODEL), asList("name", "=", EXTERNAL_ID)),
+                        asList("res_id")))
+                .thenReturn(null);
+
+        // Verify
+        assertThrows(EIPException.class, () -> companyHandler.getCompanyIdByExternalId(EXTERNAL_ID));
+    }
+
+    @Test
+    public void shouldThrowErrorWhenMultipleCompaniesFoundWithExternalId() {
+        // Setup
+        Object[] companies = {getCompanyExternalIdMap(12), getCompanyExternalIdMap(13)};
+
+        // Mock behavior
+        when(odooClient.searchAndRead(
+                        Constants.IR_MODEL,
+                        asList(asList("model", "=", Constants.COMPANY_MODEL), asList("name", "=", EXTERNAL_ID)),
+                        asList("res_id")))
+                .thenReturn(companies);
+
+        // Verify
+        assertThrows(EIPException.class, () -> companyHandler.getCompanyIdByExternalId(EXTERNAL_ID));
+    }
+
+    @Test
+    public void shouldThrowErrorWhenCompanyMappingHasUnexpectedResIdType() {
+        // Setup
+        Object[] companies = {getCompanyExternalIdMap("12")};
+
+        // Mock behavior
+        when(odooClient.searchAndRead(
+                        Constants.IR_MODEL,
+                        asList(asList("model", "=", Constants.COMPANY_MODEL), asList("name", "=", EXTERNAL_ID)),
+                        asList("res_id")))
+                .thenReturn(companies);
+
+        // Verify
+        assertThrows(EIPException.class, () -> companyHandler.getCompanyIdByExternalId(EXTERNAL_ID));
+    }
+
+    @Test
+    public void shouldReturnCompanyIdByEncounterLocation() {
+        // Setup
+        Encounter encounter = getEncounterWithLocation();
+        Object[] companies = {getCompanyExternalIdMap(12)};
+
+        // Mock behavior
+        when(odooClient.searchAndRead(
+                        Constants.IR_MODEL,
+                        asList(asList("model", "=", Constants.COMPANY_MODEL), asList("name", "=", EXTERNAL_ID)),
+                        asList("res_id")))
+                .thenReturn(companies);
+
+        // Act
+        Integer companyId = companyHandler.getCompanyIdByEncounterLocation(encounter);
+
+        // Verify
+        assertEquals(12, companyId);
+    }
+
+    @Test
+    public void shouldReturnNullAndSkipOdooLookupWhenEncounterHasNoLocation() {
+        // Setup
+        Encounter encounter = new Encounter();
+        encounter.setId(ENCOUNTER_UUID);
+
+        // Act
+        Integer companyId = companyHandler.getCompanyIdByEncounterLocation(encounter);
+
+        // Verify
+        assertNull(companyId);
+        verify(odooClient, times(0)).searchAndRead(any(), any(), any());
+    }
+
+    @Test
+    public void shouldReturnNullWhenNoCompanyFoundForEncounterLocation() {
+        // Setup
+        Encounter encounter = getEncounterWithLocation();
+
+        // Mock behavior
+        when(odooClient.searchAndRead(
+                        Constants.IR_MODEL,
+                        asList(asList("model", "=", Constants.COMPANY_MODEL), asList("name", "=", EXTERNAL_ID)),
+                        asList("res_id")))
+                .thenReturn(new Object[] {});
+
+        // Act
+        Integer companyId = companyHandler.getCompanyIdByEncounterLocation(encounter);
+
+        // Verify
+        assertNull(companyId);
+    }
+
+    private Map<String, Object> getCompanyExternalIdMap(Object resId) {
+        Map<String, Object> companyMap = new HashMap<>();
+        companyMap.put("res_id", resId);
+        return companyMap;
+    }
+
+    private Encounter getEncounterWithLocation() {
+        Encounter encounter = new Encounter();
+        encounter.setId(ENCOUNTER_UUID);
+        encounter.addLocation().setLocation(new Reference("Location/" + EXTERNAL_ID));
+        return encounter;
+    }
+}

--- a/odoo-openmrs/src/test/java/com/ozonehis/eip/odoo/openmrs/handlers/PartnerHandlerTest.java
+++ b/odoo-openmrs/src/test/java/com/ozonehis/eip/odoo/openmrs/handlers/PartnerHandlerTest.java
@@ -135,7 +135,7 @@ class PartnerHandlerTest {
         when(partnerMapper.toOdoo(patient)).thenReturn(getPartner());
 
         // Act
-        Partner result = partnerHandler.createOrUpdatePartner(producerTemplate, patient);
+        Partner result = partnerHandler.createOrUpdatePartner(producerTemplate, patient, null);
 
         // Verify
         assertEquals(12, result.getPartnerId());
@@ -160,7 +160,7 @@ class PartnerHandlerTest {
         when(partnerMapper.toOdoo(patient)).thenReturn(getPartner());
 
         // Act
-        Partner result = partnerHandler.createOrUpdatePartner(producerTemplate, patient);
+        Partner result = partnerHandler.createOrUpdatePartner(producerTemplate, patient, null);
 
         // Verify
         assertEquals(12, result.getPartnerId());

--- a/odoo-openmrs/src/test/java/com/ozonehis/eip/odoo/openmrs/handlers/SaleOrderHandlerTest.java
+++ b/odoo-openmrs/src/test/java/com/ozonehis/eip/odoo/openmrs/handlers/SaleOrderHandlerTest.java
@@ -113,7 +113,7 @@ class SaleOrderHandlerTest {
                 .thenReturn(saleOrders);
 
         // Act
-        SaleOrder result = saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(VISIT_ID_1);
+        SaleOrder result = saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(VISIT_ID_1, null);
 
         // Verify
         assertNotNull(result);
@@ -139,7 +139,7 @@ class SaleOrderHandlerTest {
                 .thenReturn(saleOrders);
 
         // Verify
-        assertThrows(EIPException.class, () -> saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(VISIT_ID_1));
+        assertThrows(EIPException.class, () -> saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(VISIT_ID_1, null));
     }
 
     @Test
@@ -155,7 +155,7 @@ class SaleOrderHandlerTest {
                 .thenReturn(saleOrders);
 
         // Act
-        SaleOrder result = saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(VISIT_ID_1);
+        SaleOrder result = saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(VISIT_ID_1, null);
 
         // Verify
         assertNull(result);
@@ -171,7 +171,7 @@ class SaleOrderHandlerTest {
                 .thenReturn(null);
 
         // Verify
-        assertThrows(EIPException.class, () -> saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(VISIT_ID_1));
+        assertThrows(EIPException.class, () -> saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(VISIT_ID_1, null));
     }
 
     @Test
@@ -190,7 +190,7 @@ class SaleOrderHandlerTest {
 
         // Act
         saleOrderHandler.updateSaleOrderIfExistsWithSaleOrderLine(
-                resource, saleOrder, VISIT_ID_1, PARTNER_ID, PATIENT_ID, producerTemplate);
+                resource, saleOrder, VISIT_ID_1, PARTNER_ID, PATIENT_ID, null, producerTemplate);
 
         // Verify
         verify(producerTemplate, times(1)).sendBody("direct:odoo-create-sale-order-line-route", saleOrderLine);
@@ -226,7 +226,7 @@ class SaleOrderHandlerTest {
 
         // Act
         saleOrderHandler.createSaleOrderWithSaleOrderLine(
-                resource, encounter, partner, VISIT_ID_1, PATIENT_ID, producerTemplate);
+                resource, encounter, partner, VISIT_ID_1, PATIENT_ID, null, producerTemplate);
 
         // Verify
         verify(producerTemplate, times(1))
@@ -256,7 +256,7 @@ class SaleOrderHandlerTest {
         ProducerTemplate producerTemplate = Mockito.mock(ProducerTemplate.class);
 
         // Act
-        saleOrderHandler.deleteSaleOrderLine(resource, VISIT_ID_1, producerTemplate);
+        saleOrderHandler.deleteSaleOrderLine(resource, VISIT_ID_1, null, producerTemplate);
 
         // Verify
         verify(saleOrderLineHandler, times(1))
@@ -284,7 +284,7 @@ class SaleOrderHandlerTest {
         ProducerTemplate producerTemplate = Mockito.mock(ProducerTemplate.class);
 
         // Act
-        saleOrderHandler.cancelSaleOrderWhenNoSaleOrderLine(partnerId, VISIT_ID_1, producerTemplate);
+        saleOrderHandler.cancelSaleOrderWhenNoSaleOrderLine(partnerId, VISIT_ID_1, null, producerTemplate);
 
         // Verify
         verify(producerTemplate, times(1))

--- a/odoo-openmrs/src/test/java/com/ozonehis/eip/odoo/openmrs/processors/EncounterProcessorTest.java
+++ b/odoo-openmrs/src/test/java/com/ozonehis/eip/odoo/openmrs/processors/EncounterProcessorTest.java
@@ -67,7 +67,8 @@ class EncounterProcessorTest extends BaseProcessorTest {
         Exchange exchange = createExchange(encounter, "c");
 
         // Mock behavior
-        when(saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(ENCOUNTER_ID)).thenReturn(saleOrder);
+        when(saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(ENCOUNTER_ID, null))
+                .thenReturn(saleOrder);
 
         // Act
         encounterProcessor.process(exchange);
@@ -75,7 +76,7 @@ class EncounterProcessorTest extends BaseProcessorTest {
         // Assert
         assertEquals(exchange.getMessage().getHeader(HEADER_FHIR_EVENT_TYPE), "u");
         assertEquals(exchange.getProperty(Constants.EXCHANGE_PROPERTY_SKIP_ENCOUNTER), false);
-        verify(saleOrderHandler, times(1)).getDraftSaleOrderIfExistsByVisitId(ENCOUNTER_ID);
+        verify(saleOrderHandler, times(1)).getDraftSaleOrderIfExistsByVisitId(ENCOUNTER_ID, null);
     }
 
     @Test
@@ -91,7 +92,8 @@ class EncounterProcessorTest extends BaseProcessorTest {
         Exchange exchange = createExchange(encounter, "c");
 
         // Mock behavior
-        when(saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(ENCOUNTER_ID)).thenReturn(null);
+        when(saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(ENCOUNTER_ID, null))
+                .thenReturn(null);
 
         // Act
         encounterProcessor.process(exchange);
@@ -99,7 +101,7 @@ class EncounterProcessorTest extends BaseProcessorTest {
         // Assert
         assertEquals(exchange.getMessage().getHeader(HEADER_FHIR_EVENT_TYPE), "c");
         assertEquals(exchange.getProperty(Constants.EXCHANGE_PROPERTY_SKIP_ENCOUNTER), true);
-        verify(saleOrderHandler, times(1)).getDraftSaleOrderIfExistsByVisitId(ENCOUNTER_ID);
+        verify(saleOrderHandler, times(1)).getDraftSaleOrderIfExistsByVisitId(ENCOUNTER_ID, null);
     }
 
     @Test
@@ -110,7 +112,8 @@ class EncounterProcessorTest extends BaseProcessorTest {
         Exchange exchange = createExchange(encounter, "c");
 
         // Mock behavior
-        when(saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(ENCOUNTER_ID)).thenReturn(null);
+        when(saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(ENCOUNTER_ID, null))
+                .thenReturn(null);
 
         // Act
         encounterProcessor.process(exchange);
@@ -118,6 +121,6 @@ class EncounterProcessorTest extends BaseProcessorTest {
         // Assert
         assertEquals(exchange.getMessage().getHeader(HEADER_FHIR_EVENT_TYPE), "c");
         assertEquals(exchange.getProperty(Constants.EXCHANGE_PROPERTY_SKIP_ENCOUNTER), true);
-        verify(saleOrderHandler, times(0)).getDraftSaleOrderIfExistsByVisitId(ENCOUNTER_ID);
+        verify(saleOrderHandler, times(0)).getDraftSaleOrderIfExistsByVisitId(ENCOUNTER_ID, null);
     }
 }

--- a/odoo-openmrs/src/test/java/com/ozonehis/eip/odoo/openmrs/processors/MedicationRequestProcessorTest.java
+++ b/odoo-openmrs/src/test/java/com/ozonehis/eip/odoo/openmrs/processors/MedicationRequestProcessorTest.java
@@ -93,8 +93,8 @@ class MedicationRequestProcessorTest extends BaseProcessorTest {
         partner.setPartnerId(PARTNER_ID);
 
         // Mock behavior
-        when(partnerHandler.createOrUpdatePartner(any(), eq(patient))).thenReturn(partner);
-        when(saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(ENCOUNTER_VISIT_ID))
+        when(partnerHandler.createOrUpdatePartner(any(), eq(patient), any())).thenReturn(partner);
+        when(saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(eq(ENCOUNTER_VISIT_ID), any()))
                 .thenReturn(saleOrder);
 
         // Act
@@ -109,6 +109,7 @@ class MedicationRequestProcessorTest extends BaseProcessorTest {
                         eq(ENCOUNTER_VISIT_ID),
                         eq(PARTNER_ID),
                         eq(PATIENT_ID),
+                        any(),
                         any());
         verify(saleOrderHandler, times(0))
                 .createSaleOrderWithSaleOrderLine(
@@ -117,6 +118,7 @@ class MedicationRequestProcessorTest extends BaseProcessorTest {
                         eq(partner),
                         eq(ENCOUNTER_VISIT_ID),
                         eq(PATIENT_ID),
+                        any(),
                         any());
     }
 
@@ -145,8 +147,8 @@ class MedicationRequestProcessorTest extends BaseProcessorTest {
         partner.setPartnerId(PARTNER_ID);
 
         // Mock behavior
-        when(partnerHandler.createOrUpdatePartner(any(), eq(patient))).thenReturn(partner);
-        when(saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(ENCOUNTER_VISIT_ID))
+        when(partnerHandler.createOrUpdatePartner(any(), eq(patient), any())).thenReturn(partner);
+        when(saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(eq(ENCOUNTER_VISIT_ID), any()))
                 .thenReturn(null);
 
         // Act
@@ -156,7 +158,13 @@ class MedicationRequestProcessorTest extends BaseProcessorTest {
         assertEquals(exchange.getMessage().getHeader(HEADER_FHIR_EVENT_TYPE), "c");
         verify(saleOrderHandler, times(0))
                 .updateSaleOrderIfExistsWithSaleOrderLine(
-                        eq(medicationRequest), any(), eq(ENCOUNTER_VISIT_ID), eq(PARTNER_ID), eq(PATIENT_ID), any());
+                        eq(medicationRequest),
+                        any(),
+                        eq(ENCOUNTER_VISIT_ID),
+                        eq(PARTNER_ID),
+                        eq(PATIENT_ID),
+                        any(),
+                        any());
         verify(saleOrderHandler, times(1))
                 .createSaleOrderWithSaleOrderLine(
                         eq(medicationRequest),
@@ -164,6 +172,7 @@ class MedicationRequestProcessorTest extends BaseProcessorTest {
                         eq(partner),
                         eq(ENCOUNTER_VISIT_ID),
                         eq(PATIENT_ID),
+                        any(),
                         any());
     }
 
@@ -191,17 +200,24 @@ class MedicationRequestProcessorTest extends BaseProcessorTest {
         partner.setPartnerId(PARTNER_ID);
 
         // Mock behavior
-        when(partnerHandler.createOrUpdatePartner(any(), eq(patient))).thenReturn(partner);
+        when(partnerHandler.createOrUpdatePartner(any(), eq(patient), any())).thenReturn(partner);
 
         // Act
         medicationRequestProcessor.process(exchange);
 
         // Assert
         assertEquals(exchange.getMessage().getHeader(HEADER_FHIR_EVENT_TYPE), "u");
-        verify(saleOrderHandler, times(1)).deleteSaleOrderLine(eq(medicationRequest), eq(ENCOUNTER_VISIT_ID), any());
+        verify(saleOrderHandler, times(1))
+                .deleteSaleOrderLine(eq(medicationRequest), eq(ENCOUNTER_VISIT_ID), any(), any());
         verify(saleOrderHandler, times(0))
                 .updateSaleOrderIfExistsWithSaleOrderLine(
-                        eq(medicationRequest), any(), eq(ENCOUNTER_VISIT_ID), eq(PARTNER_ID), eq(PATIENT_ID), any());
+                        eq(medicationRequest),
+                        any(),
+                        eq(ENCOUNTER_VISIT_ID),
+                        eq(PARTNER_ID),
+                        eq(PATIENT_ID),
+                        any(),
+                        any());
         verify(saleOrderHandler, times(0))
                 .createSaleOrderWithSaleOrderLine(
                         eq(medicationRequest),
@@ -209,6 +225,7 @@ class MedicationRequestProcessorTest extends BaseProcessorTest {
                         eq(partner),
                         eq(ENCOUNTER_VISIT_ID),
                         eq(PATIENT_ID),
+                        any(),
                         any());
     }
 }

--- a/odoo-openmrs/src/test/java/com/ozonehis/eip/odoo/openmrs/processors/ServiceRequestProcessorTest.java
+++ b/odoo-openmrs/src/test/java/com/ozonehis/eip/odoo/openmrs/processors/ServiceRequestProcessorTest.java
@@ -90,8 +90,8 @@ class ServiceRequestProcessorTest extends BaseProcessorTest {
         partner.setPartnerId(PARTNER_ID);
 
         // Mock behavior
-        when(partnerHandler.createOrUpdatePartner(any(), eq(patient))).thenReturn(partner);
-        when(saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(ENCOUNTER_VISIT_ID))
+        when(partnerHandler.createOrUpdatePartner(any(), eq(patient), any())).thenReturn(partner);
+        when(saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(eq(ENCOUNTER_VISIT_ID), any()))
                 .thenReturn(saleOrder);
 
         // Act
@@ -106,10 +106,17 @@ class ServiceRequestProcessorTest extends BaseProcessorTest {
                         eq(ENCOUNTER_VISIT_ID),
                         eq(PARTNER_ID),
                         eq(PATIENT_ID),
+                        any(),
                         any());
         verify(saleOrderHandler, times(0))
                 .createSaleOrderWithSaleOrderLine(
-                        eq(serviceRequest), eq(encounter), eq(partner), eq(ENCOUNTER_VISIT_ID), eq(PATIENT_ID), any());
+                        eq(serviceRequest),
+                        eq(encounter),
+                        eq(partner),
+                        eq(ENCOUNTER_VISIT_ID),
+                        eq(PATIENT_ID),
+                        any(),
+                        any());
     }
 
     @Test
@@ -136,8 +143,8 @@ class ServiceRequestProcessorTest extends BaseProcessorTest {
         partner.setPartnerId(PARTNER_ID);
 
         // Mock behavior
-        when(partnerHandler.createOrUpdatePartner(any(), eq(patient))).thenReturn(partner);
-        when(saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(ENCOUNTER_VISIT_ID))
+        when(partnerHandler.createOrUpdatePartner(any(), eq(patient), any())).thenReturn(partner);
+        when(saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(eq(ENCOUNTER_VISIT_ID), any()))
                 .thenReturn(null);
 
         // Act
@@ -147,10 +154,22 @@ class ServiceRequestProcessorTest extends BaseProcessorTest {
         assertEquals(exchange.getMessage().getHeader(HEADER_FHIR_EVENT_TYPE), "c");
         verify(saleOrderHandler, times(0))
                 .updateSaleOrderIfExistsWithSaleOrderLine(
-                        eq(serviceRequest), any(), eq(ENCOUNTER_VISIT_ID), eq(PARTNER_ID), eq(PATIENT_ID), any());
+                        eq(serviceRequest),
+                        any(),
+                        eq(ENCOUNTER_VISIT_ID),
+                        eq(PARTNER_ID),
+                        eq(PATIENT_ID),
+                        any(),
+                        any());
         verify(saleOrderHandler, times(1))
                 .createSaleOrderWithSaleOrderLine(
-                        eq(serviceRequest), eq(encounter), eq(partner), eq(ENCOUNTER_VISIT_ID), eq(PATIENT_ID), any());
+                        eq(serviceRequest),
+                        eq(encounter),
+                        eq(partner),
+                        eq(ENCOUNTER_VISIT_ID),
+                        eq(PATIENT_ID),
+                        any(),
+                        any());
     }
 
     // Test for handling completed status
@@ -180,8 +199,8 @@ class ServiceRequestProcessorTest extends BaseProcessorTest {
         SaleOrder saleOrder = new SaleOrder();
 
         // Mock behavior
-        when(partnerHandler.createOrUpdatePartner(any(), eq(patient))).thenReturn(partner);
-        when(saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(ENCOUNTER_VISIT_ID))
+        when(partnerHandler.createOrUpdatePartner(any(), eq(patient), any())).thenReturn(partner);
+        when(saleOrderHandler.getDraftSaleOrderIfExistsByVisitId(eq(ENCOUNTER_VISIT_ID), any()))
                 .thenReturn(saleOrder);
 
         // Act
@@ -196,6 +215,7 @@ class ServiceRequestProcessorTest extends BaseProcessorTest {
                         eq(ENCOUNTER_VISIT_ID),
                         eq(PARTNER_ID),
                         eq(PATIENT_ID),
+                        any(),
                         any());
     }
 }


### PR DESCRIPTION
JIRA: https://mekomsolutions.atlassian.net/browse/C2C-461

 This PR adds optional company-aware order syncing for MedicationRequest and ServiceRequest flows. When `ENABLE_ENCOUNTER_LOCATION_TO_COMPANY_MAPPING` is enabled, the integration resolves the Encounter location UUID to an Odoo `res.company` then creates/updates partners, sale orders, and sale order lines under that company.